### PR TITLE
Fixed incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hopefully in the future it will also be possible to do the following:
 
 * Attach a Sublime Text view to a particular terminal window.
 
-This plugin was originally based on Rtools by Karthik Ram: https://github.com/karthikram/Rtools
+This plugin was originally based on Rtools by Karthik Ram: https://github.com/karthik/Rtools
 
 ## Installation
 


### PR DESCRIPTION
The link to RTools is incorrect since it points to my old GitHub username. Fixed this in the README.
